### PR TITLE
Handle hex variant of apostrophe entity

### DIFF
--- a/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/message/RichTextMessageParser.kt
+++ b/matrix/services/sync/src/main/kotlin/app/dapk/st/matrix/sync/internal/sync/message/RichTextMessageParser.kt
@@ -27,7 +27,13 @@ class RichMessageParser(
 
 }
 
-private fun String.removeHtmlEntities() = this.replace("&quot;", "\"").replace("&#39;", "'").replace("&apos;", "'").replace("&amp;", "&")
+private fun String.removeHtmlEntities() = this
+    .replace("&quot;", "\"")
+    .replace("&#39;", "'")
+    .replace("&apos;", "'")
+    .replace("&apos;", "'")
+    .replace("&amp;", "&")
+    .replace("&#x27;", "'")
 
 private fun String.dropTextFallback() = this.lines()
     .dropWhile { it.startsWith("> ") || it.isEmpty() }

--- a/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/RichTextMessageParserTest.kt
+++ b/matrix/services/sync/src/test/kotlin/app/dapk/st/matrix/sync/internal/sync/RichTextMessageParserTest.kt
@@ -76,6 +76,10 @@ class RichTextMessageParserTest {
             expected = RichText(listOf(Normal("Hello world! foo's bar")))
         ),
         Case(
+            input = "Hello world! foo&#x27;s bar",
+            expected = RichText(listOf(Normal("Hello world! foo's bar")))
+        ),
+        Case(
             input = "Hello world! foo&apos;s bar",
             expected = RichText(listOf(Normal("Hello world! foo's bar")))
         ),


### PR DESCRIPTION
Fixes the hex variant of the `&apos` - `&#x27;` coming through as text