### PR TITLE
Fix login error "f: illegal input" (e.g. when using Dendrite)

### DIFF
--- a/matrix/services/auth/src/main/kotlin/app/dapk/st/matrix/auth/internal/AuthRequest.kt
+++ b/matrix/services/auth/src/main/kotlin/app/dapk/st/matrix/auth/internal/AuthRequest.kt
@@ -61,7 +61,6 @@ internal data class Auth(
 @Serializable
 data class ApiAuthResponse(
     @SerialName("access_token") val accessToken: String,
-    @SerialName("home_server") val homeServer: String,
     @SerialName("user_id") override val userId: UserId,
     @SerialName("device_id") override val deviceId: DeviceId,
     @SerialName("well_known") val wellKnown: ApiWellKnown? = null,


### PR DESCRIPTION
According to [the matrix spec](https://spec.matrix.org/v1.6/client-server-api/#_matrixclientv3login_user-identifier) the login-response field "home_server" has been deprecated and:
_"Clients should extract the `server_name` from `user_id` (by splitting at the first colon) if they require it."_.

[chat-engine](https://github.com/ouchadam/chat-engine) currently requires this field to be available when deserializing the [ApiAuthResponse](https://github.com/ouchadam/chat-engine/pull/34/files#diff-2f7f0f2059e0da997d7fbc419f8508c50ea56da7303f7d22123767432783984eL64) class from JSON. As a result, for any matrix server that does not provide the "home_server"-field in the response to `POST /_matrix/client/r0/login` (e.g. [Dendrite](https://matrix.org/docs/projects/server/dendrite)), an exception displayed to the user as `"f: Illigal input"` is thrown.

**Included Changes**
* This PR removes the field from [ApiAuthResponse](https://github.com/ouchadam/chat-engine/pull/34/files#diff-2f7f0f2059e0da997d7fbc419f8508c50ea56da7303f7d22123767432783984eL64) - it was not used anywhere in the code.

**Does That Fix The Issue?**
* Yes! With this PR, logging in to Dendrite succeeds - Tested on the latest version of small-talk.